### PR TITLE
docs: update dead lx-music-api-server link to community fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ https://ghproxy.net/raw.githubusercontent.com/pdone/lx-music-source/main/qdy/lat
 - [SixYin](https://www.sixyin.com/)
 - [Huibq/keep-alive](https://github.com/Huibq/keep-alive/)
 - [LX](https://www.lxmusic.cc/)
-- [ikun](https://github.com/lxmusics/lx-music-api-server)
+- [ikun](https://github.com/MeoProject/lx-music-api-server)
 
 ## 项目地址
 - [lx-music-desktop](https://github.com/lyswhut/lx-music-desktop)


### PR DESCRIPTION
The data-source list links to `github.com/lxmusics/lx-music-api-server` which returns 404 — the original org's repo has been removed. Updated to `MeoProject/lx-music-api-server`, the most-starred community fork (verified live, 200). If there's a different canonical successor, happy to swap.